### PR TITLE
fix(sanitize): require dompurify on run

### DIFF
--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -1,6 +1,3 @@
-var dompurify = require('dompurify');
-
-
 var allowedUriSchemesRegexp = /^(https?|mailto|#)/i;
 var absoluteUriRegexp = /^[a-zA-Z]+:\//;
 
@@ -16,9 +13,12 @@ function linkHrefHook(node) {
   node.removeAttribute('href');
 };
 
-dompurify.addHook('afterSanitizeAttributes', linkHrefHook);
-
 function sanitize(source, config) {
+  var dompurify = require('dompurify');
+  
+  dompurify.removeAllHooks();
+  dompurify.addHook('afterSanitizeAttributes', linkHrefHook);
+
   return dompurify.sanitize(source, config);
 }
 


### PR DESCRIPTION
Prevent `dompurify` from being required and executed, when method not used.

This prevents an error when including `blueprint-markdown-renderer`, even if not running the `sanitize` method, in node.

Ref APIARY-5698